### PR TITLE
Add UPX to build process

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,12 +6,13 @@ RUN apk add --update --no-cache ca-certificates make bash git
 ADD . /project
 WORKDIR /project
 
-# Compile binaries
-RUN make
-
 # Currently, upx is not available as an alpine package for arm64 devices:
 # https://github.com/upx/upx/issues/419
-# RUN make pack
+RUN make install-upx
+
+# Compile binaries
+RUN make
+RUN make pack
 
 FROM scratch
 

--- a/Makefile
+++ b/Makefile
@@ -21,6 +21,10 @@ install-tools:
 		mvdan.cc/gofumpt/gofumports \
 		github.com/sebdah/markdown-toc
 
+# Installs the latest UPX binary to GOBIN.
+install-upx:
+	./scripts/install_upx.sh
+
 # Lints go source code
 lint:
 	golangci-lint run --enable-all
@@ -39,8 +43,10 @@ has-changes:
 build:
 	./scripts/build.sh
 
+# Creates docker image for various architectures.
 docker:
 	./scripts/docker.sh
 
+# Compresses binaries
 pack:
 	upx `find ./bin -type f`

--- a/scripts/install_upx.sh
+++ b/scripts/install_upx.sh
@@ -1,0 +1,18 @@
+#!/usr/bin/env bash
+
+GO_BIN_DIR=$(go env GOROOT)/bin
+GO_ARCH=$(go env GOARCH)
+
+UPX_VERSION=$(git ls-remote --tags --refs --sort="v:refname" https://github.com/upx/upx.git | tail -n1 | sed 's/.*\///')
+UPX_URL=https://github.com/upx/upx/releases/download/${UPX_VERSION}/upx-${UPX_VERSION:1}-${GO_ARCH}_linux.tar.xz
+
+# Download latest UPX release and unarchive
+wget "${UPX_URL}" -O upx.tar.xz
+tar -xf upx.tar.xz
+
+# Move UPX binary into go bin directory
+mv upx-"${UPX_VERSION:1}"-"${GO_ARCH}"_linux/upx "${GO_BIN_DIR}"
+
+# Tidy up after ourselves
+rm upx.tar.xz
+rm -rf upx-"${UPX_VERSION:1}"-"${GO_ARCH}"_linux


### PR DESCRIPTION
Adds a script to install the latest version of UPX that should work across amd64 and arm64, should reduce
docker image size to about a third of its original.