### PR TITLE
Set pod affinity for backup jobs that use volumes

### DIFF
--- a/manifests/utilities/bitwarden/backup-cron.yaml
+++ b/manifests/utilities/bitwarden/backup-cron.yaml
@@ -11,6 +11,16 @@ spec:
     spec:
       template:
         spec:
+          affinity:
+            podAffinity:
+              requiredDuringSchedulingIgnoredDuringExecution:
+                - topologyKey: kubernetes.io/hostname
+                  labelSelector:
+                    matchExpressions:
+                      - key: app
+                        operator: In
+                        values:
+                          - bitwarden
           imagePullSecrets:
             - name: registry
           containers:

--- a/manifests/utilities/pihole/ftl-backup-cron.yaml
+++ b/manifests/utilities/pihole/ftl-backup-cron.yaml
@@ -11,6 +11,16 @@ spec:
     spec:
       template:
         spec:
+          affinity:
+            podAffinity:
+              requiredDuringSchedulingIgnoredDuringExecution:
+                - topologyKey: kubernetes.io/hostname
+                  labelSelector:
+                    matchExpressions:
+                      - key: app
+                        operator: In
+                        values:
+                          - pihole
           imagePullSecrets:
             - name: registry
           containers:

--- a/manifests/utilities/pihole/gravity-backup-cron.yaml
+++ b/manifests/utilities/pihole/gravity-backup-cron.yaml
@@ -11,6 +11,16 @@ spec:
     spec:
       template:
         spec:
+          affinity:
+            podAffinity:
+              requiredDuringSchedulingIgnoredDuringExecution:
+                - topologyKey: kubernetes.io/hostname
+                  labelSelector:
+                    matchExpressions:
+                      - key: app
+                        operator: In
+                        values:
+                          - pihole
           imagePullSecrets:
             - name: registry
           containers:


### PR DESCRIPTION
Sets up the backup jobs for bitwarden & pihole to only be scheduled onto the same nodes as the
actual pods running those applications. This should solve the issue where the jobs are started
on different nodes and cannot mount the volumes as longhorn does not allow `ReadWriteMany` on
volumes.