### PR TITLE
Add traefik middleware to modify headers for websockets

### DIFF
--- a/manifests/kube-system/config/traefik/middleware.yaml
+++ b/manifests/kube-system/config/traefik/middleware.yaml
@@ -1,0 +1,6 @@
+http:
+  middlewares:
+    sslheader:
+      headers:
+        customRequestHeaders:
+          X-Forwarded-Proto: "https"

--- a/manifests/kube-system/config/traefik/traefik.yaml
+++ b/manifests/kube-system/config/traefik/traefik.yaml
@@ -1,0 +1,28 @@
+api:
+  insecure: true
+  dashboard: true
+
+metrics:
+  prometheus:
+    entryPoint: metrics
+
+providers:
+  file:
+    directory: /config/common
+  kubernetesIngress: {}
+
+entryPoints:
+  web:
+    address: :80
+    http:
+      redirections:
+        entryPoint:
+          to: websecure
+          scheme: https
+  websecure:
+    address: :443
+    http:
+      middlewares:
+        - sslheader@file
+  metrics:
+    address: :8082

--- a/manifests/kube-system/kustomization.yaml
+++ b/manifests/kube-system/kustomization.yaml
@@ -10,3 +10,9 @@ secretGenerator:
   - name: traefik
     envs:
     - secrets/traefik
+
+configMapGenerator:
+  - name: traefik
+    files:
+    - config/traefik/traefik.yaml
+    - config/traefik/middleware.yaml

--- a/manifests/kube-system/traefik/daemonset.yaml
+++ b/manifests/kube-system/traefik/daemonset.yaml
@@ -23,7 +23,7 @@ spec:
       - image: traefik:latest
         name: traefik
         env:
-          - name: PILOT_TOKEN
+          - name: TRAEFIK_PILOT_TOKEN
             valueFrom:
               secretKeyRef:
                 key: pilot.token
@@ -45,14 +45,15 @@ spec:
             add:
               - NET_BIND_SERVICE
         args:
-        - --api.insecure
-        - --api.dashboard
-        - --metrics.prometheus
-        - --metrics.prometheus.entryPoint=metrics
-        - --providers.kubernetesingress
-        - --entryPoints.web.address=:80
-        - --entryPoints.websecure.address=:443
-        - --entryPoints.metrics.address=:8082
-        - --entrypoints.web.http.redirections.entryPoint.to=websecure
-        - --entrypoints.web.http.redirections.entryPoint.scheme=https
-        - --pilot.token=$(PILOT_TOKEN)
+        - --configFile=/config/traefik.yaml
+        volumeMounts:
+          - mountPath: /config/traefik.yaml
+            name: traefik
+            subPath: traefik.yaml
+          - mountPath: /config/common/middleware.yaml
+            name: traefik
+            subPath: middleware.yaml
+      volumes:
+        - name: traefik
+          configMap:
+            name: traefik


### PR DESCRIPTION
After upgrading traefik, the websockets used in the longhorn-ui stopped working, complaining about CORS
requests. After some searching it appears I needed to add a middleware to add X-Forwarded-Proto headers
to all requests.

This commit modifies traefik to use configuration files, and applies the request header middleware to
the default entrypoint.