### PR TITLE
Various fixes

### DIFF
--- a/manifests/homelab/prometheus-exporters/home-assistant/deployment.yaml
+++ b/manifests/homelab/prometheus-exporters/home-assistant/deployment.yaml
@@ -30,6 +30,11 @@ spec:
         env:
         - name: HOME_ASSISTANT_URL
           value: http://home-assistant.utilities.svc.cluster.local:8123
+        - name: HOME_ASSISTANT_TOKEN
+          valueFrom:
+            secretKeyRef:
+              key: home-assistant.token
+              name: home-assistant
         - name: TRACER_DISABLED
           value: "true"
         readinessProbe:

--- a/manifests/kube-system/config/traefik/traefik.yaml
+++ b/manifests/kube-system/config/traefik/traefik.yaml
@@ -32,8 +32,8 @@ entryPoints:
 ping:
   entryPoint: ping
 
-tracing:
-  jaeger:
-    collector:
-      endpoint: http://jaeger.monitoring.svc.cluster.local:14268/api/traces?format=jaeger.thrift
-    samplingServerURL: http://jaeger.monitoring.svc.cluster.local:5778/sampling
+#tracing:
+#  jaeger:
+#    collector:
+#      endpoint: http://jaeger.monitoring.svc.cluster.local:14268/api/traces?format=jaeger.thrift
+#    samplingServerURL: http://jaeger.monitoring.svc.cluster.local:5778/sampling

--- a/manifests/monitoring/jaeger/deployment.yaml
+++ b/manifests/monitoring/jaeger/deployment.yaml
@@ -32,6 +32,9 @@ spec:
           value: /badger
         - name: BADGER_DIRECTORY_KEY
           value: /badger/key
+        resources:
+          limits:
+            memory: 1Gi
         readinessProbe:
           httpGet:
             path: /


### PR DESCRIPTION
* Disable tracing on traefik, it's doing loads and pushing jaeger's memory usage up a lot
* Add 1Gi memory limit to jaeger
* Add missing token to home-assistant prometheus exporter