### PR TITLE
Add script to unify crontab on all nodes

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -55,3 +55,6 @@ docker:
 
 pack:
 	upx `find ./bin -type f`
+
+install-cron-jobs:
+	./scripts/install_cron_jobs.sh

--- a/crontab
+++ b/crontab
@@ -1,0 +1,9 @@
+# Delete unused container images
+@daily sudo k3s crictl rmi --prune
+
+# Clear logs older than 1 day
+@daily sudo journalctl --vacuum-time=1d
+
+# Clear rotated and compressed logs
+@daily sudo find /var/log -type f -regex ".*\.gz$" -delete
+@daily sudo find /var/log -type f -regex ".*\.[0-9]$" -delete

--- a/manifests/longhorn-system/longhorn/manager/daemonset.yaml
+++ b/manifests/longhorn-system/longhorn/manager/daemonset.yaml
@@ -25,7 +25,6 @@ spec:
             privileged: true
           command:
             - longhorn-manager
-            - -d
             - daemon
             - --engine-image
             - longhornio/longhorn-engine:master

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -1,16 +1,15 @@
 #!/usr/bin/env bash
 
+# This script iterates over each subdirectory in /cmd that contains a main.go file
+# and builds the binary. Each binary is placed within /bin. Compilation details are
+# linked in the binary via ldflags.
+
 DIR=$(pwd)
 BIN_DIR=${DIR}/bin
-
-# Application metadata
 APP_VERSION=$(git describe --tags --always)
-
 rm -rf "${BIN_DIR}"
 mkdir -p "${BIN_DIR}"
 
-# Iterates over each subdirectory in ~/cmd that contains a main.go file
-# and builds the binary. Each binary is placed within ~/bin.
 for dir in $(find "${DIR}"/cmd -name 'main.go' -print0 | xargs -0 -n1 dirname | sort | uniq); do
   APP_NAME=$(basename "${dir}")
   APP_DESCRIPTION=$(cat "${dir}"/DESCRIPTION)

--- a/scripts/docker.sh
+++ b/scripts/docker.sh
@@ -1,5 +1,8 @@
 #!/usr/bin/env bash
 
+# This script is used to build the docker image that contains all bespoke applications ran
+# in the k3s cluster. If no go files have changed, nothing is done here.
+
 CHANGES=$(git diff --name-only HEAD HEAD~1 | grep .go)
 if [ -z "$CHANGES" ]
 then

--- a/scripts/install_cron_jobs.sh
+++ b/scripts/install_cron_jobs.sh
@@ -1,0 +1,14 @@
+#!/usr/bin/env bash
+
+# This script installs the crontab file located at the root of this repository onto all the desired
+# servers via SSH. This allows me to easily modify the cron jobs that are ran on each node in the
+# k3s cluster, and makes sure they're all the same.
+
+DIR=$(pwd)
+SSH_SERVERS="homelab-0 homelab-1 homelab-2 homelab-3"
+SSH_USER="ubuntu"
+CRONTAB_DATA=$(cat "${DIR}/crontab")
+
+for SSH_SERVER in $(echo "${SSH_SERVERS}" | sort | uniq); do
+  echo "$CRONTAB_DATA" | ssh "${SSH_USER}@${SSH_SERVER}" "crontab -"
+done

--- a/scripts/k8s_lint.sh
+++ b/scripts/k8s_lint.sh
@@ -1,5 +1,8 @@
 #!/usr/bin/env bash
 
+# This script runs validation for all kubernetes manifests, excluding secrets and configuration files
+# that are managed with kustomize.
+
 DIR=$(pwd)
 MANIFEST_DIR=${DIR}/manifests
 FILES=$(find "${MANIFEST_DIR}" -type d \( -path "**/secrets" -o -path "**/config" \) -prune -false -o -name '*.yaml' | sort | uniq)


### PR DESCRIPTION
Introduces a shell script + Makefile recipe that installs a crontab file on all nodes in the
cluster. This crontab currently has jobs for pruning container images, and clearing log files
older than 24 hours.

It also disables debug logging for longhorn, which was causing a lot of log buildup.