### PR TITLE
Create cronjob to clean elasticsearch indexes

### DIFF
--- a/manifests/storage/elasticsearch/cronjob.yaml
+++ b/manifests/storage/elasticsearch/cronjob.yaml
@@ -1,0 +1,34 @@
+apiVersion: batch/v1beta1
+kind: CronJob
+metadata:
+  name: elasticsearch-index-cleaner
+  labels:
+    app: elasticsearch-index-cleaner
+spec:
+  schedule: 0 1 * * *
+  jobTemplate:
+    spec:
+      template:
+        spec:
+          imagePullSecrets:
+            - name: registry
+          containers:
+            - image: ghcr.io/davidsbond/homelab:latest
+              name: elasticsearch-index-cleaner
+              command:
+                - /bin/elasticsearch-index-cleaner
+              env:
+                - name: ELASTICSEARCH_HOST
+                  value: http://elasticsearch.storage.svc.cluster.local:9200
+                - name: INDEX_FORMATS
+                  value: "jaeger-service-%v-%v-%v jaeger-span-%v-%v-%v logstash-%v.%v.%v"
+                - name: MAX_AGE
+                  value: 24h
+                - name: TRACER_DISABLED
+                  value: 'true'
+              readinessProbe:
+                httpGet:
+                  path: /__/health
+                  port: 8081
+                initialDelaySeconds: 5
+          restartPolicy: OnFailure

--- a/manifests/storage/elasticsearch/kustomization.yaml
+++ b/manifests/storage/elasticsearch/kustomization.yaml
@@ -5,3 +5,4 @@ resources:
 - deployment.yaml
 - service.yaml
 - persistentvolumeclaim.yaml
+- cronjob.yaml


### PR DESCRIPTION
Runs at 1am, deleting the previous day's logs.