### PR TITLE
Set CPU limit for elasticsearch

### DIFF
--- a/manifests/storage/elasticsearch/deployment.yaml
+++ b/manifests/storage/elasticsearch/deployment.yaml
@@ -53,6 +53,7 @@ spec:
         resources:
           limits:
             memory: 2Gi
+            cpu: "1"
       volumes:
         - name: data
           persistentVolumeClaim:


### PR DESCRIPTION
Left elasticsearch unattended for a few hours and it spiked the hell out of every node it got put onto. Adding in
a CPU limit of 1.