### PR TITLE
Expose prometheus endpoints in elasticsearch

### DIFF
--- a/manifests/storage/config/elasticsearch/elasticsearch.yml
+++ b/manifests/storage/config/elasticsearch/elasticsearch.yml
@@ -1,0 +1,8 @@
+discovery.type: single-node
+bootstrap.memory_lock: true
+cluster.name: homelab
+prometheus.indices: false
+http.host: 0.0.0.0
+network.host: 0.0.0.0
+http.port: 9200
+transport.tcp.port: 9300

--- a/manifests/storage/elasticsearch/deployment.yaml
+++ b/manifests/storage/elasticsearch/deployment.yaml
@@ -14,9 +14,13 @@ spec:
     metadata:
       labels:
         app: elasticsearch
+      annotations:
+        prometheus.io/path: /_prometheus/metrics
+        prometheus.io/port: "9200"
+        prometheus.io/scrape: "true"
     spec:
       securityContext:
-        fsGroup: 82
+        fsGroup: 1000
       initContainers:
       - name: create
         image: busybox:1.28
@@ -24,29 +28,39 @@ spec:
         volumeMounts:
         - mountPath: /usr/share/elasticsearch/data
           name: data
+          subPath: data
+        - mountPath: /usr/share/elasticsearch/plugins
+          name: data
+          subPath: plugins
       - name: file-permissions
         image: busybox:1.28
         command: ['chown', '-R', '1000:1000', '/usr/share/elasticsearch/']
         volumeMounts:
         - mountPath: /usr/share/elasticsearch/data
           name: data
+          subPath: data
+        - mountPath: /usr/share/elasticsearch/plugins
+          name: data
+          subPath: plugins
       containers:
       - name: elasticsearch
         image: elasticsearch:7.10.1
         env:
-          - name: discovery.type
-            value: single-node
-          - name: bootstrap.memory_lock
-            value: "true"
-          - name: cluster.name
-            value: homelab
           - name: ES_JAVA_OPTS
             value: "-Xms1g -Xmx1g"
         volumeMounts:
           - mountPath: /usr/share/elasticsearch/data
             name: data
+            subPath: data
+          - mountPath: /usr/share/elasticsearch/plugins
+            name: data
+            subPath: plugins
+          - name: elasticsearch
+            mountPath: /usr/share/elasticsearch/config/elasticsearch.yml
+            subPath: elasticsearch.yml
         readinessProbe:
           timeoutSeconds: 120
+          initialDelaySeconds: 120
           httpGet:
             port: 9200
             path: /_cluster/health?wait_for_status=yellow&timeout=120s
@@ -58,3 +72,6 @@ spec:
         - name: data
           persistentVolumeClaim:
             claimName: elasticsearch
+        - name: elasticsearch
+          configMap:
+            name: elasticsearch

--- a/manifests/storage/elasticsearch/persistentvolumeclaim.yaml
+++ b/manifests/storage/elasticsearch/persistentvolumeclaim.yaml
@@ -8,4 +8,4 @@ spec:
   - ReadWriteOnce
   resources:
     requests:
-      storage: 2Gi
+      storage: 10Gi

--- a/manifests/storage/kustomization.yaml
+++ b/manifests/storage/kustomization.yaml
@@ -14,6 +14,9 @@ configMapGenerator:
 - name: docker-registry
   files:
   - config/docker-registry/garbage-collector.yaml
+- name: elasticsearch
+  files:
+  - config/elasticsearch/elasticsearch.yml
 
 secretGenerator:
 - name: minio


### PR DESCRIPTION
Switches elasticsearch to a configuration file, sets up plugin persistence and adds
annotations to get prometheus exporting metrics after installing the plugin.