### PR TITLE
Upgrade longhorn to v1.1.0

### DIFF
--- a/manifests/longhorn-system/longhorn/clusterrole.yaml
+++ b/manifests/longhorn-system/longhorn/clusterrole.yaml
@@ -32,7 +32,8 @@ rules:
     verbs: ["get", "watch", "list", "delete", "update", "create"]
   - apiGroups: ["longhorn.io"]
     resources: ["volumes", "volumes/status", "engines", "engines/status", "replicas", "replicas/status", "settings",
-                "engineimages", "engineimages/status", "nodes", "nodes/status", "instancemanagers", "instancemanagers/status"]
+                "engineimages", "engineimages/status", "nodes", "nodes/status", "instancemanagers", "instancemanagers/status",
+                "sharemanagers", "sharemanagers/status"]
     verbs: ["*"]
   - apiGroups: ["coordination.k8s.io"]
     resources: ["leases"]

--- a/manifests/longhorn-system/longhorn/crd/kustomization.yaml
+++ b/manifests/longhorn-system/longhorn/crd/kustomization.yaml
@@ -2,13 +2,14 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 
 resources:
-  - engine.yaml
-  - engineimage.yaml
-  - instancemanager.yaml
-  - node.yaml
-  - replica.yaml
-  - setting.yaml
-  - volume.yaml
-  - volumesnapshot.yaml
-  - volumesnapshotclass.yaml
-  - volumesnapshotcontents.yaml
+- engine.yaml
+- engineimage.yaml
+- instancemanager.yaml
+- node.yaml
+- replica.yaml
+- setting.yaml
+- volume.yaml
+- volumesnapshot.yaml
+- volumesnapshotclass.yaml
+- volumesnapshotcontents.yaml
+- sharemanager.yaml

--- a/manifests/longhorn-system/longhorn/crd/sharemanager.yaml
+++ b/manifests/longhorn-system/longhorn/crd/sharemanager.yaml
@@ -1,0 +1,42 @@
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  labels:
+    longhorn-manager: ShareManager
+  name: sharemanagers.longhorn.io
+spec:
+  group: longhorn.io
+  names:
+    kind: ShareManager
+    listKind: ShareManagerList
+    plural: sharemanagers
+    shortNames:
+      - lhsm
+    singular: sharemanager
+  scope: Namespaced
+  versions:
+    - name: v1beta1
+      served: true
+      storage: true
+      schema:
+        openAPIV3Schema:
+          type: object
+          properties:
+            spec:
+              x-kubernetes-preserve-unknown-fields: true
+            status:
+              x-kubernetes-preserve-unknown-fields: true
+      subresources:
+        status: {}
+      additionalPrinterColumns:
+        - name: State
+          type: string
+          description: The state of the share manager
+          jsonPath: .status.state
+        - name: Node
+          type: string
+          description: The node that the share manager is owned by
+          jsonPath: .status.ownerID
+        - name: Age
+          type: date
+          jsonPath: .metadata.creationTimestamp

--- a/manifests/longhorn-system/longhorn/driver-deployer/deployment.yaml
+++ b/manifests/longhorn-system/longhorn/driver-deployer/deployment.yaml
@@ -14,18 +14,18 @@ spec:
     spec:
       initContainers:
         - name: wait-longhorn-manager
-          image: longhornio/longhorn-manager:master
+          image: longhornio/longhorn-manager:v1.1.0
           command: ['sh', '-c', 'while [ $(curl -m 1 -s -o /dev/null -w "%{http_code}" http://longhorn-backend:9500/v1) != "200" ]; do echo waiting; sleep 2; done']
       containers:
         - name: longhorn-driver-deployer
-          image: longhornio/longhorn-manager:master
+          image: longhornio/longhorn-manager:v1.1.0
           imagePullPolicy: IfNotPresent
           command:
             - longhorn-manager
             - -d
             - deploy-driver
             - --manager-image
-            - longhornio/longhorn-manager:master
+            - longhornio/longhorn-manager:v1.1.0
             - --manager-url
             - http://longhorn-backend:9500/v1
           env:

--- a/manifests/longhorn-system/longhorn/manager/daemonset.yaml
+++ b/manifests/longhorn-system/longhorn/manager/daemonset.yaml
@@ -19,7 +19,7 @@ spec:
     spec:
       containers:
         - name: longhorn-manager
-          image: longhornio/longhorn-manager:master
+          image: longhornio/longhorn-manager:v1.1.0
           imagePullPolicy: IfNotPresent
           securityContext:
             privileged: true
@@ -28,11 +28,13 @@ spec:
             - -j
             - daemon
             - --engine-image
-            - longhornio/longhorn-engine:master
+            - longhornio/longhorn-engine:v1.1.0
             - --instance-manager-image
-            - longhornio/longhorn-instance-manager:master
+            - longhornio/longhorn-instance-manager:v1_20201216
             - --manager-image
-            - longhornio/longhorn-manager:master
+            - longhornio/longhorn-manager:v1.1.0
+            - --share-manager-image
+            - longhornio/longhorn-share-manager:v1.1.0
             - --service-account
             - longhorn
           ports:

--- a/manifests/longhorn-system/longhorn/ui/deployment.yaml
+++ b/manifests/longhorn-system/longhorn/ui/deployment.yaml
@@ -16,7 +16,7 @@ spec:
     spec:
       containers:
         - name: longhorn-ui
-          image: longhornio/longhorn-ui:master
+          image: longhornio/longhorn-ui:v1.1.0
           imagePullPolicy: IfNotPresent
           securityContext:
             runAsUser: 0


### PR DESCRIPTION
Pins longhorn to v1.1.0, removing references to master. Adds new CRDs and RBAC permissions.