### PR TITLE
Remove prometheus plugin before install

### DIFF
--- a/manifests/storage/elasticsearch/deployment.yaml
+++ b/manifests/storage/elasticsearch/deployment.yaml
@@ -67,7 +67,7 @@ spec:
         image: elasticsearch:7.10.1
         env:
           - name: ES_JAVA_OPTS
-            value: "-Xms2g -Xmx2g"
+            value: "-Xms1g -Xmx1g"
         volumeMounts:
           - mountPath: /usr/share/elasticsearch/data
             name: data

--- a/manifests/storage/elasticsearch/deployment.yaml
+++ b/manifests/storage/elasticsearch/deployment.yaml
@@ -46,7 +46,15 @@ spec:
         - mountPath: /usr/share/elasticsearch/plugins
           name: data
           subPath: plugins
-      # Third container installs the prometheus plugin. This will expose prometheus metrics to be scraped.
+      # Third container removes the prometheus plugin directory if it already exists.
+      - name: remove-prometheus-plugin
+        image: busybox:1.28
+        command: ['rm', '-rf', '/usr/share/elasticsearch/plugins/prometheus-exporter']
+        volumeMounts:
+          - mountPath: /usr/share/elasticsearch/plugins
+            name: data
+            subPath: plugins
+      # Fourth container installs the prometheus plugin. This will expose prometheus metrics to be scraped.
       - name: install-prometheus-plugin
         image: elasticsearch:7.10.1
         command: ['./bin/elasticsearch-plugin', 'install', '-b', 'https://github.com/vvanholl/elasticsearch-prometheus-exporter/releases/download/7.10.1.0/prometheus-exporter-7.10.1.0.zip']


### PR DESCRIPTION
Updates the elasticsearch init containers to remove the plugin first if it exists, this was causing
an issue when elasticsearch restarts as it doesn't gracefully handle a plugin already being
installed.