### PR TITLE
Increase postgres PV size

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,7 @@ To start working:
 ## Project structure
 
 * `cmd` - Entry points to any bespoke applications.
+* `hack` - Node host specific config files and tweaks.
 * `internal` - Packages used throughout the application code.
 * `manifests` - Kubernetes manifests to run all my homelab applications.
 * `scripts` - Bash scripts for working within the repository.
@@ -105,9 +106,10 @@ the master node upgrades.
 
 ## Node maintenance
 
-The [crontab](./crontab) file at the root of the repository is used on all nodes in the cluster, it describes scheduled
-tasks that clear out temporary and old files on the filesystem (/tmp, /var/log etc) and performs package upgrades on a
-weekly basis. It will also prune container images that are no longer in use.
+The [hack](./hack) diretory at the root of the repository contains files used on all nodes in the cluster, it contains a 
+[crontab](./hack/crontab) file that describes scheduled tasks that clear out temporary and old files on the filesystem 
+(/tmp, /var/log etc) and performs package upgrades on a weekly basis. It will also prune container images that are no 
+longer in use.
 
 The crontab file can be deployed to all nodes using the `make install-cron-jobs` recipe. This command will copy over the
 contents of the local crontab file to each node via SSH. You need to have used `ssh copy-key-id` for each node so you don't

--- a/hack/crontab
+++ b/hack/crontab
@@ -1,3 +1,7 @@
+# This file contains all my custom cron jobs to run on each k3s node host, each job is a general
+# maintenance thing, either to keep things up-to-date or to reduce resource usage. This is managed
+# from the central homelab repository and shouldn't be modified directly on the host.
+
 # Delete unused container images
 @daily sudo k3s crictl rmi --prune
 

--- a/hack/multipath.conf
+++ b/hack/multipath.conf
@@ -1,0 +1,9 @@
+defaults {
+    user_friendly_names yes
+}
+
+# Prevent multipath daemon from adding additional block devices created by Longhorn
+# https://github.com/longhorn/longhorn/issues/1210
+blacklist {
+    devnode "^sd[a-z0-9]+"
+}

--- a/manifests/storage/postgres/deployment.yaml
+++ b/manifests/storage/postgres/deployment.yaml
@@ -31,16 +31,6 @@ spec:
               name: postgres
         - name: PGDATA
           value: /postgres/data
-        livenessProbe:
-          exec:
-            command:
-            - /bin/sh
-            - -c
-            - exec pg_isready -U postgres -h 127.0.0.1 -p 5432
-          failureThreshold: 3
-          initialDelaySeconds: 30
-          successThreshold: 1
-          timeoutSeconds: 1
         readinessProbe:
           exec:
             command:

--- a/manifests/storage/postgres/persistentvolumeclaim.yaml
+++ b/manifests/storage/postgres/persistentvolumeclaim.yaml
@@ -8,4 +8,4 @@ spec:
   - ReadWriteOnce
   resources:
     requests:
-      storage: 1Gi
+      storage: 10Gi

--- a/scripts/install_cron_jobs.sh
+++ b/scripts/install_cron_jobs.sh
@@ -4,7 +4,7 @@
 # servers via SSH. This allows me to easily modify the cron jobs that are ran on each node in the
 # k3s cluster, and makes sure they're all the same.
 
-DIR=$(pwd)
+DIR=$(pwd)/hack
 SSH_SERVERS="homelab-0 homelab-1 homelab-2 homelab-3"
 SSH_USER="ubuntu"
 CRONTAB_DATA=$(cat "${DIR}/crontab")


### PR DESCRIPTION
Increases postgres PV to 10Gi, removes liveness check due to excessive restarting. Also
moves crontab into hack directory and added the `multipath.conf` file in order to fix an
issue I was experiencing with longhorn where volumes were getting stuck attaching.