### PR TITLE
Modify k3s nodes to use tailscale for networking

### DIFF
--- a/hack/k3s-agent.service
+++ b/hack/k3s-agent.service
@@ -26,3 +26,8 @@ ExecStartPre=-/sbin/modprobe br_netfilter
 ExecStartPre=-/sbin/modprobe overlay
 ExecStart=/usr/local/bin/k3s \
     agent \
+    --advertise-address ${TAILSCALE_ADDR} \
+    --bind-address ${TAILSCALE_ADDR} \
+    --node-ip ${TAILSCALE_ADDR} \
+    --node-external-ip ${TAILSCALE_ADDR} \
+    --node-label "tailscale.com/addr=${TAILSCALE_ADDR}" \

--- a/hack/k3s.service
+++ b/hack/k3s.service
@@ -26,4 +26,9 @@ ExecStartPre=-/sbin/modprobe br_netfilter
 ExecStartPre=-/sbin/modprobe overlay
 ExecStart=/usr/local/bin/k3s \
     server \
-    --no-deploy traefik \
+    --disable traefik \
+    --advertise-address ${TAILSCALE_ADDR} \
+    --bind-address ${TAILSCALE_ADDR} \
+    --node-ip ${TAILSCALE_ADDR} \
+    --node-external-ip ${TAILSCALE_ADDR} \
+    --node-label "tailscale.com/addr=${TAILSCALE_ADDR}" \

--- a/scripts/node_envs.sh
+++ b/scripts/node_envs.sh
@@ -1,0 +1,2 @@
+export TAILSCALE_ADDR=$(tailscale status -json | jq -r .Self.TailAddr)
+export K3S_NODE_NAME=k3s-$(echo $TAILSCALE_ADDR | tr . -)


### PR DESCRIPTION
Sets all bind/listen/advertise addresses to use the `TAILSCALE_ADDR` environment
variable that is now set on startup.