### PR TITLE
Exclude longhorn and cert-manager from fluentbit logging.

### DIFF
--- a/manifests/cert-manager/kustomization.yaml
+++ b/manifests/cert-manager/kustomization.yaml
@@ -18,3 +18,6 @@ secretGenerator:
 
 generatorOptions:
   disableNameSuffixHash: true
+
+commonAnnotations:
+  fluentbit.io/exclude: "true"

--- a/manifests/longhorn-system/kustomization.yaml
+++ b/manifests/longhorn-system/kustomization.yaml
@@ -18,3 +18,6 @@ secretGenerator:
 
 generatorOptions:
   disableNameSuffixHash: true
+
+commonAnnotations:
+  fluentbit.io/exclude: "true"


### PR DESCRIPTION
Longhorn spits out a very large amount of logs, this should reduce that somewhat by using the
custom annotation available with fluentbit's kubernetes filter.