### PR TITLE
Use DNS over HTTPS for pihole

### DIFF
--- a/manifests/homelab/prometheus-exporters/pihole/cronjob.yaml
+++ b/manifests/homelab/prometheus-exporters/pihole/cronjob.yaml
@@ -29,7 +29,7 @@ spec:
                   key: push.gateway.url
                   name: prometheus
             - name: PIHOLE_URL
-              value: http://pihole.utilities.svc.cluster.local:8000
+              value: http://pihole-ui.utilities.svc.cluster.local:8000
             readinessProbe:
               httpGet:
                 path: /__/health

--- a/manifests/utilities/pihole/deployment.yaml
+++ b/manifests/utilities/pihole/deployment.yaml
@@ -5,6 +5,8 @@ metadata:
   labels:
     app: pihole
 spec:
+  strategy:
+    type: Recreate
   replicas: 1
   selector:
     matchLabels:
@@ -27,6 +29,11 @@ spec:
             secretKeyRef:
               name: pihole
               key: pihole.password
+        # Point DNS to cloudflared for DNS over HTTPS.
+        - name: DNS1
+          value: 127.0.0.1#5053
+        - name: DNS2
+          value: ''
         volumeMounts:
         - name: pihole
           mountPath: /etc/pihole
@@ -34,6 +41,11 @@ spec:
         - name: pihole
           mountPath: /etc/dnsmasq.d
           subPath: dnsmasq
+        readinessProbe:
+          tcpSocket:
+            port: 80
+      - name: cloudflared
+        image: klutchell/cloudflared:2019.12.0
       volumes:
       - name: pihole
         persistentVolumeClaim:

--- a/manifests/utilities/pihole/gravity-backup-cron.yaml
+++ b/manifests/utilities/pihole/gravity-backup-cron.yaml
@@ -6,7 +6,7 @@ metadata:
     app: pihole-gravity-db-backup
 spec:
   concurrencyPolicy: Replace
-  schedule: 15 * * * *
+  schedule: 0 * * * *
   jobTemplate:
     spec:
       template:

--- a/manifests/utilities/pihole/ingress.yaml
+++ b/manifests/utilities/pihole/ingress.yaml
@@ -18,7 +18,7 @@ spec:
       paths:
       - backend:
           service:
-            name: pihole
+            name: pihole-ui
             port:
               number: 8000
         path: /

--- a/manifests/utilities/pihole/kustomization.yaml
+++ b/manifests/utilities/pihole/kustomization.yaml
@@ -3,7 +3,8 @@ kind: Kustomization
 
 resources:
 - deployment.yaml
-- service.yaml
+- service-dns.yaml
+- service-ui.yaml
 - persistentvolumeclaim.yaml
 - ingress.yaml
 - ftl-backup-cron.yaml

--- a/manifests/utilities/pihole/service-dns.yaml
+++ b/manifests/utilities/pihole/service-dns.yaml
@@ -1,14 +1,11 @@
 apiVersion: v1
 kind: Service
 metadata:
-  name: pihole
+  name: pihole-dns
 spec:
   selector:
     app: pihole
   ports:
-  - port: 8000
-    targetPort: 80
-    name: pihole-admin
   - port: 53
     targetPort: 53
     protocol: TCP
@@ -18,4 +15,5 @@ spec:
     protocol: UDP
     name: dns-udp
   externalIPs:
-  - 192.168.1.140
+  - 100.100.86.74
+  - 100.126.136.14

--- a/manifests/utilities/pihole/service-ui.yaml
+++ b/manifests/utilities/pihole/service-ui.yaml
@@ -1,0 +1,11 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: pihole-ui
+spec:
+  selector:
+    app: pihole
+  ports:
+    - port: 8000
+      targetPort: 80
+      name: pihole-admin


### PR DESCRIPTION
* Adds a `cloudscaled` sidecar container that pihole uses for DNS over HTTPS
* Split the pihole service into two, so we don't expose the UI on external ips, now it can
only be accessed via the ingress
* Adds a readiness probe for pihole
* DNS external ips are now served via Tailscale, rather than the local network ids. This means I can
use my pihole DNS on the go, when not connected to my local network.