### PR TITLE
Tweak postgres resources

### DIFF
--- a/manifests/homelab/config/directory/config.yaml
+++ b/manifests/homelab/config/directory/config.yaml
@@ -32,6 +32,3 @@ items:
 - name: Traefik
   url: https://traefik.homelab.dsb.dev
   description: Reverse Proxy Dasboard
-- name: Kibana
-  url: https://kibana.homelab.dsb.dev
-  description: Elasticsearch UI

--- a/manifests/storage/postgres/deployment.yaml
+++ b/manifests/storage/postgres/deployment.yaml
@@ -14,8 +14,14 @@ spec:
         app: postgres
     spec:
       containers:
-      - image: postgres:alpine
+      - image: postgres:13.1-alpine
         name: postgres
+        command:
+          - docker-entrypoint.sh
+          - -c
+          - work_mem=156MB
+          - -c
+          - max_parallel_workers_per_gather=0
         env:
         - name: POSTGRES_DB
           value: postgres
@@ -41,6 +47,13 @@ spec:
           initialDelaySeconds: 30
           successThreshold: 1
           timeoutSeconds: 1
+        resources:
+          requests:
+            cpu: 100m
+            memory: 400Mi
+          limits:
+            cpu: "1"
+            memory: 2Gi
         volumeMounts:
         - name: postgres
           mountPath: /postgres


### PR DESCRIPTION
Pins the postgres version to 13.1, sets `work_mem` to `156MB` and `max_parallel_workers_per_gather` to 0, sets some
resource requests and limits too. Also includes removing kibana from my directory page.