### PR TITLE
Home-Assistant customisations

### DIFF
--- a/manifests/utilities/config/home-assistant/configuration.yaml
+++ b/manifests/utilities/config/home-assistant/configuration.yaml
@@ -9,9 +9,13 @@ prometheus:
 # Store things in postgres
 recorder:
   db_url: !secret db_dsn
+  purge_keep_days: 3
 
 # Enable UI
 frontend:
+
+# Enables configuration UI
+config:
 
 # Enable history
 history:
@@ -43,3 +47,13 @@ pi_hole:
     ssl: true
     verify_ssl: true
     api_key: !secret pihole_api_key
+
+# Checks for available updates
+updater:
+
+# Discover some devices automatically
+discovery:
+
+# Enable yaml based dashboards
+lovelace:
+  mode: yaml

--- a/manifests/utilities/config/home-assistant/groups.yaml
+++ b/manifests/utilities/config/home-assistant/groups.yaml
@@ -1,1 +1,9 @@
-{}
+lights:
+  name: Lights
+  entities:
+    - light.bedroom_lamp
+    - light.hallway_light
+    - light.landing_light
+    - light.living_room_light
+    - light.office_light
+    - light.spare_bedroom_lamp

--- a/manifests/utilities/config/home-assistant/scripts.yaml
+++ b/manifests/utilities/config/home-assistant/scripts.yaml
@@ -1,1 +1,35 @@
-{}
+# The 'Roxanne' script changes the colour of all lights in the lights group
+# to red at full brightness.
+all_lights_red:
+  alias: Roxanne
+  sequence:
+    - data:
+        brightness_pct: 100
+        entity_id: group.lights
+        color_name: red
+        effect: 'none'
+      service: light.turn_on
+
+# The 'Barbie Girl' script changes the colour of all lights in the lights group
+# to pink at full brightness.
+all_lights_pink:
+  alias: Barbie Girl
+  sequence:
+    - data:
+        brightness_pct: 100
+        entity_id: group.lights
+        color_name: pink
+        effect: 'none'
+      service: light.turn_on
+
+# The 'Rainbow' script sets all lights in the lights group on a colour loop at
+# full brightness.
+all_lights_random:
+  alias: Rainbow
+  sequence:
+    - data:
+        brightness_pct: 100
+        entity_id: group.lights
+        color_name: white
+        effect: 'colorloop'
+      service: light.turn_on

--- a/manifests/utilities/config/home-assistant/ui-lovelace.yaml
+++ b/manifests/utilities/config/home-assistant/ui-lovelace.yaml
@@ -1,0 +1,24 @@
+title: Dashboard
+views:
+- title: Home Automation
+  path: home-automation
+  theme: ''
+  badges: []
+  cards:
+  - type: entities
+    entities:
+    - entity: light.bedroom_lamp
+    - entity: light.hallway_light
+    - entity: light.landing_light
+    - entity: light.living_room_light
+    - entity: light.office_light
+    - entity: light.spare_bedroom_lamp
+    state_color: true
+    title: Lights
+  - type: entities
+    entities:
+    - entity: script.all_lights_red
+    - entity: script.all_lights_pink
+    - entity: script.all_lights_random
+    title: Light Scripts
+    state_color: true

--- a/manifests/utilities/home-assistant/deployment.yaml
+++ b/manifests/utilities/home-assistant/deployment.yaml
@@ -29,6 +29,9 @@ spec:
           - mountPath: /config/scripts.yaml
             subPath: scripts.yaml
             name: home-assistant-config
+          - mountPath: /config/ui-lovelace.yaml
+            subPath: ui-lovelace.yaml
+            name: home-assistant-config
           - mountPath: /config/scenes.yaml
             subPath: scenes.yaml
             name: home-assistant-config

--- a/manifests/utilities/kustomization.yaml
+++ b/manifests/utilities/kustomization.yaml
@@ -21,6 +21,7 @@ configMapGenerator:
   - config/home-assistant/scenes.yaml
   - config/home-assistant/scripts.yaml
   - config/home-assistant/groups.yaml
+  - config/home-assistant/ui-lovelace.yaml
 
 secretGenerator:
 - name: pihole


### PR DESCRIPTION
Configures home-assistant to use YAML based dashboard configurations, enables the updater, automatic
device discovery and purging of the recorder data every 3 days. Adds a group for all the lights
and a couple scripts to modify the colour of all lights.