### PR TITLE
Add cleanup job for fluentbit

### DIFF
--- a/manifests/kube-system/fluent-bit/db-cleanup-cron.yaml
+++ b/manifests/kube-system/fluent-bit/db-cleanup-cron.yaml
@@ -1,0 +1,35 @@
+apiVersion: batch/v1beta1
+kind: CronJob
+metadata:
+  name: fluent-bit-cleanup
+  labels:
+    app: fluent-bit-cleanup
+spec:
+  schedule: 0 1 * * *
+  jobTemplate:
+    spec:
+      template:
+        spec:
+          containers:
+            - image: registry.homelab.dsb.dev/library/postgres:13.1-alpine
+              name: cleanup
+              command:
+                - psql
+                - -c
+                - "DELETE FROM fluentbit WHERE time < NOW() - INTERVAL '2 days'"
+              env:
+                - name: PGHOST
+                  value: postgres.storage.svc.cluster.local
+                - name: PGDATABASE
+                  value: fluentbit
+                - name: PGUSER
+                  valueFrom:
+                    secretKeyRef:
+                      key: postgres.user
+                      name: postgres
+                - name: PGPASSWORD
+                  valueFrom:
+                    secretKeyRef:
+                      key: postgres.password
+                      name: postgres
+          restartPolicy: Never

--- a/manifests/kube-system/fluent-bit/db-init.yaml
+++ b/manifests/kube-system/fluent-bit/db-init.yaml
@@ -6,7 +6,7 @@ spec:
   template:
     spec:
       containers:
-        - image: postgres:13.1-alpine
+        - image: registry.homelab.dsb.dev/library/postgres:13.1-alpine
           name: createdb
           command:
             - createdb

--- a/manifests/kube-system/fluent-bit/kustomization.yaml
+++ b/manifests/kube-system/fluent-bit/kustomization.yaml
@@ -7,4 +7,4 @@ resources:
 - daemonset.yaml
 - serviceaccount.yaml
 - db-init.yaml
-
+- db-cleanup-cron.yaml

--- a/manifests/utilities/firefly/db-init.yaml
+++ b/manifests/utilities/firefly/db-init.yaml
@@ -6,7 +6,7 @@ spec:
   template:
     spec:
       containers:
-        - image: postgres:13.1-alpine
+        - image: registry.homelab.dsb.dev/library/postgres:13.1-alpine
           name: createdb
           command:
             - createdb

--- a/manifests/utilities/home-assistant/db-init.yaml
+++ b/manifests/utilities/home-assistant/db-init.yaml
@@ -6,7 +6,7 @@ spec:
   template:
     spec:
       containers:
-        - image: postgres:13.1-alpine
+        - image: registry.homelab.dsb.dev/library/postgres:13.1-alpine
           name: createdb
           command:
             - createdb


### PR DESCRIPTION
Removes all logs older than 2 days. Also updates job images to use proxied
images.