### PR TITLE
Upgrade homeassistant to 2021.1.5

### DIFF
--- a/manifests/utilities/home-assistant/deployment.yaml
+++ b/manifests/utilities/home-assistant/deployment.yaml
@@ -17,7 +17,7 @@ spec:
         app: home-assistant
     spec:
       containers:
-      - image: registry.homelab.dsb.dev/homeassistant/home-assistant:2021.1.0
+      - image: registry.homelab.dsb.dev/homeassistant/home-assistant:2021.1.5
         name: home-assistant
         readinessProbe:
           tcpSocket:


### PR DESCRIPTION
Upgrades due to security bulletin:

https://www.home-assistant.io/blog/2021/01/14/security-bulletin/