### PR TITLE
Throttle logging into postgres

### DIFF
--- a/manifests/kube-system/config/fluent-bit/filter-kubernetes.conf
+++ b/manifests/kube-system/config/fluent-bit/filter-kubernetes.conf
@@ -8,4 +8,4 @@
     Merge_Log           On
     Merge_Log_Key       log_processed
     K8S-Logging.Parser  On
-    K8S-Logging.Exclude Off
+    K8S-Logging.Exclude On

--- a/manifests/kube-system/config/fluent-bit/filter-throttle.conf
+++ b/manifests/kube-system/config/fluent-bit/filter-throttle.conf
@@ -1,0 +1,6 @@
+[FILTER]
+    Name                throttle
+    Match               *
+    Rate                10
+    Window              300
+    Interval            1s

--- a/manifests/kube-system/config/fluent-bit/fluent-bit.conf
+++ b/manifests/kube-system/config/fluent-bit/fluent-bit.conf
@@ -9,4 +9,5 @@
 
 @INCLUDE input-kubernetes.conf
 @INCLUDE filter-kubernetes.conf
+@INCLUDE filter-throttle.conf
 @INCLUDE output-postgres.conf

--- a/manifests/kube-system/fluent-bit/db-cleanup-cron.yaml
+++ b/manifests/kube-system/fluent-bit/db-cleanup-cron.yaml
@@ -5,7 +5,7 @@ metadata:
   labels:
     app: fluent-bit-cleanup
 spec:
-  schedule: 0 1 * * *
+  schedule: 0 * * * *
   jobTemplate:
     spec:
       template:
@@ -16,7 +16,7 @@ spec:
               command:
                 - psql
                 - -c
-                - "DELETE FROM fluentbit WHERE time < NOW() - INTERVAL '2 days'"
+                - "DELETE FROM fluentbit WHERE time < NOW() - INTERVAL '1 day'"
               env:
                 - name: PGHOST
                   value: postgres.storage.svc.cluster.local

--- a/manifests/kube-system/kustomization.yaml
+++ b/manifests/kube-system/kustomization.yaml
@@ -24,6 +24,7 @@ configMapGenerator:
 - name: fluent-bit
   files:
   - config/fluent-bit/filter-kubernetes.conf
+  - config/fluent-bit/filter-throttle.conf
   - config/fluent-bit/fluent-bit.conf
   - config/fluent-bit/input-kubernetes.conf
   - config/fluent-bit/output-postgres.conf


### PR DESCRIPTION
Postgres instance gets filled up way too quick and is unhappy when trying to delete records. Throttling should help this
somewhat. Longhorn is responsible for most of the logs by the looks of it.