### PR TITLE
Add more CPU + memory limits

### DIFF
--- a/internal/health/index.go
+++ b/internal/health/index.go
@@ -5,6 +5,7 @@ package health
 import (
 	"context"
 	"net/http"
+	"sort"
 	"text/template"
 
 	"github.com/gorilla/mux"
@@ -62,6 +63,10 @@ func (t *HTTP) Get(w http.ResponseWriter, r *http.Request) {
 		t.Error(r.Context(), w, http.StatusInternalServerError, err.Error())
 		return
 	}
+
+	sort.Slice(apps, func(i, j int) bool {
+		return apps[i].Name < apps[j].Name
+	})
 
 	if err = tpl.Execute(w, apps); err != nil {
 		t.Error(r.Context(), w, http.StatusInternalServerError, err.Error())

--- a/manifests/homelab/minecraft-backup/cronjob.yaml
+++ b/manifests/homelab/minecraft-backup/cronjob.yaml
@@ -52,4 +52,8 @@ spec:
                 path: /__/health
                 port: 8081
               initialDelaySeconds: 5
+            resources:
+              limits:
+                memory: "128Mi"
+                cpu: "500m"
           restartPolicy: OnFailure

--- a/manifests/storage/minio/deployment.yaml
+++ b/manifests/storage/minio/deployment.yaml
@@ -59,3 +59,4 @@ spec:
         resources:
           limits:
             memory: 512Mi
+            cpu: "1"

--- a/manifests/storage/postgres/backup-cron.yaml
+++ b/manifests/storage/postgres/backup-cron.yaml
@@ -49,4 +49,8 @@ spec:
                   path: /__/health
                   port: 8081
                 initialDelaySeconds: 5
+              resources:
+                limits:
+                  memory: "128Mi"
+                  cpu: "500m"
           restartPolicy: OnFailure

--- a/manifests/utilities/bitwarden/backup-cron.yaml
+++ b/manifests/utilities/bitwarden/backup-cron.yaml
@@ -53,6 +53,10 @@ spec:
                   path: /__/health
                   port: 8081
                 initialDelaySeconds: 5
+              resources:
+                limits:
+                  memory: "128Mi"
+                  cpu: "500m"
           volumes:
             - name: bitwarden
               persistentVolumeClaim:

--- a/manifests/utilities/photoprism/backup-cron.yaml
+++ b/manifests/utilities/photoprism/backup-cron.yaml
@@ -54,6 +54,10 @@ spec:
                   path: /__/health
                   port: 8081
                 initialDelaySeconds: 5
+              resources:
+                limits:
+                  memory: "128Mi"
+                  cpu: "500m"
           volumes:
             - name: photoprism
               persistentVolumeClaim:

--- a/manifests/utilities/pihole/ftl-backup-cron.yaml
+++ b/manifests/utilities/pihole/ftl-backup-cron.yaml
@@ -54,6 +54,10 @@ spec:
                   path: /__/health
                   port: 8081
                 initialDelaySeconds: 5
+              resources:
+                limits:
+                  memory: "128Mi"
+                  cpu: "500m"
           volumes:
           - name: pihole
             persistentVolumeClaim:

--- a/manifests/utilities/pihole/gravity-backup-cron.yaml
+++ b/manifests/utilities/pihole/gravity-backup-cron.yaml
@@ -54,6 +54,10 @@ spec:
                   path: /__/health
                   port: 8081
                 initialDelaySeconds: 5
+              resources:
+                limits:
+                  memory: "128Mi"
+                  cpu: "500m"
           volumes:
             - name: pihole
               persistentVolumeClaim:


### PR DESCRIPTION
Noticed backup jobs cause reasonable spikes in CPU usage across nodes and on the minio instance that they
use. Introduces some memory/cpu limits to keep things from getting exhausted the more I add.