### PR TITLE
Apply stricter CPU limits on things that spike

### DIFF
--- a/manifests/homelab/minecraft-backup/cronjob.yaml
+++ b/manifests/homelab/minecraft-backup/cronjob.yaml
@@ -60,5 +60,5 @@ spec:
             resources:
               limits:
                 memory: "128Mi"
-                cpu: "500m"
+                cpu: "100m"
           restartPolicy: OnFailure

--- a/manifests/monitoring/prometheus/server/deployment.yaml
+++ b/manifests/monitoring/prometheus/server/deployment.yaml
@@ -31,6 +31,7 @@ spec:
           resources:
             limits:
               memory: 2Gi
+              cpu: 500m
           livenessProbe:
             httpGet:
               path: /-/healthy

--- a/manifests/storage/minio/deployment.yaml
+++ b/manifests/storage/minio/deployment.yaml
@@ -59,4 +59,4 @@ spec:
         resources:
           limits:
             memory: 512Mi
-            cpu: "1"
+            cpu: 100m


### PR DESCRIPTION
Currently, prometheus, minio and the minecraf backup cause CPU spikes. Adding these small CPU limits
should mitigate this somewhat.