### PR TITLE
Change FTP backup to create date keyed zip files.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ bin/
 .idea/
 .terraform/
 tfplan
+manifests/output.yaml

--- a/cmd/ftp-backup/DESCRIPTION
+++ b/cmd/ftp-backup/DESCRIPTION
@@ -1,1 +1,1 @@
-Job that backs up the content of an FTP server to a desired blob store.
+Job that backs up the content of an FTP server to a desired blob store as a single zip file.

--- a/manifests/kube-system/traefik/daemonset.yaml
+++ b/manifests/kube-system/traefik/daemonset.yaml
@@ -53,6 +53,10 @@ spec:
           - mountPath: /config/common/middleware.yaml
             name: traefik
             subPath: middleware.yaml
+        resources:
+          limits:
+            memory: 512Mi
+            cpu: 200m
         livenessProbe:
           httpGet:
             port: 8082


### PR DESCRIPTION
Instead of copying the whole FTP server verbatim into the bucket, use a zip file instead
to save on some space and hopefully speed upload up a bit.