### PR TITLE
Use imagePullPolicy IfNotPresent for all instances of latest tag.

### DIFF
--- a/manifests/experimental/bytecrypt/deployment.yaml
+++ b/manifests/experimental/bytecrypt/deployment.yaml
@@ -24,6 +24,7 @@ spec:
         - name: registry
       containers:
         - image: ghcr.io/davidsbond/bytecrypt:latest
+          imagePullPolicy: IfNotPresent
           name: bytecrypt
           command:
             - /bin/server

--- a/manifests/homelab/directory/deployment.yaml
+++ b/manifests/homelab/directory/deployment.yaml
@@ -25,6 +25,7 @@ spec:
       - name: registry
       containers:
       - image: ghcr.io/davidsbond/homelab:latest
+        imagePullPolicy: IfNotPresent
         name: directory
         command:
         - /bin/directory

--- a/manifests/homelab/health-dashboard/deployment.yaml
+++ b/manifests/homelab/health-dashboard/deployment.yaml
@@ -27,6 +27,7 @@ spec:
       - name: registry
       containers:
       - image: ghcr.io/davidsbond/homelab:latest
+        imagePullPolicy: IfNotPresent
         name: health-dashboard
         command:
         - /bin/health-dashboard

--- a/manifests/homelab/minecraft-backup/cronjob.yaml
+++ b/manifests/homelab/minecraft-backup/cronjob.yaml
@@ -14,6 +14,7 @@ spec:
           - name: registry
           containers:
           - image: ghcr.io/davidsbond/homelab:latest
+            imagePullPolicy: IfNotPresent
             name: ftp-backup
             command:
             - /bin/ftp-backup

--- a/manifests/homelab/prometheus-exporters/coronavirus/cronjob.yaml
+++ b/manifests/homelab/prometheus-exporters/coronavirus/cronjob.yaml
@@ -14,6 +14,7 @@ spec:
           - name: registry
           containers:
           - image: ghcr.io/davidsbond/homelab:latest
+            imagePullPolicy: IfNotPresent
             name: prometheus-exporter-coronavirus
             command:
             - /bin/prometheus-exporter-coronavirus

--- a/manifests/homelab/prometheus-exporters/home-assistant/deployment.yaml
+++ b/manifests/homelab/prometheus-exporters/home-assistant/deployment.yaml
@@ -25,6 +25,7 @@ spec:
       - name: registry
       containers:
       - image: ghcr.io/davidsbond/homelab:latest
+        imagePullPolicy: IfNotPresent
         name: prometheus-exporter-home-assistant
         command:
         - /bin/prometheus-exporter-home-assistant

--- a/manifests/homelab/prometheus-exporters/homehub/cronjob.yaml
+++ b/manifests/homelab/prometheus-exporters/homehub/cronjob.yaml
@@ -14,6 +14,7 @@ spec:
           - name: registry
           containers:
           - image: ghcr.io/davidsbond/homelab:latest
+            imagePullPolicy: IfNotPresent
             name: prometheus-exporter-homehub
             command:
             - /bin/prometheus-exporter-homehub

--- a/manifests/homelab/prometheus-exporters/minecraft/cronjob.yaml
+++ b/manifests/homelab/prometheus-exporters/minecraft/cronjob.yaml
@@ -14,6 +14,7 @@ spec:
           - name: registry
           containers:
           - image: ghcr.io/davidsbond/homelab:latest
+            imagePullPolicy: IfNotPresent
             name: prometheus-exporter-minecraft
             command:
             - /bin/prometheus-exporter-minecraft

--- a/manifests/homelab/prometheus-exporters/pihole/cronjob.yaml
+++ b/manifests/homelab/prometheus-exporters/pihole/cronjob.yaml
@@ -14,6 +14,7 @@ spec:
           - name: registry
           containers:
           - image: ghcr.io/davidsbond/homelab:latest
+            imagePullPolicy: IfNotPresent
             name: prometheus-exporter-pihole
             command:
             - /bin/prometheus-exporter-pihole

--- a/manifests/homelab/prometheus-exporters/speedtest/cronjob.yaml
+++ b/manifests/homelab/prometheus-exporters/speedtest/cronjob.yaml
@@ -14,6 +14,7 @@ spec:
           - name: registry
           containers:
           - image: ghcr.io/davidsbond/homelab:latest
+            imagePullPolicy: IfNotPresent
             name: prometheus-exporter-speedtest
             command:
             - /bin/prometheus-exporter-speedtest

--- a/manifests/homelab/prometheus-exporters/synology/cronjob.yaml
+++ b/manifests/homelab/prometheus-exporters/synology/cronjob.yaml
@@ -14,6 +14,7 @@ spec:
           - name: registry
           containers:
           - image: ghcr.io/davidsbond/homelab:latest
+            imagePullPolicy: IfNotPresent
             name: prometheus-exporter-synology
             command:
             - /bin/prometheus-exporter-synology

--- a/manifests/homelab/prometheus-exporters/weather/cronjob.yaml
+++ b/manifests/homelab/prometheus-exporters/weather/cronjob.yaml
@@ -14,6 +14,7 @@ spec:
           - name: registry
           containers:
           - image: ghcr.io/davidsbond/homelab:latest
+            imagePullPolicy: IfNotPresent
             name: prometheus-exporter-weather
             command:
             - /bin/prometheus-exporter-weather

--- a/manifests/homelab/prometheus-exporters/worldping/cronjob.yaml
+++ b/manifests/homelab/prometheus-exporters/worldping/cronjob.yaml
@@ -14,6 +14,7 @@ spec:
           - name: registry
           containers:
           - image: ghcr.io/davidsbond/homelab:latest
+            imagePullPolicy: IfNotPresent
             name: prometheus-exporter-worldping
             command:
             - /bin/prometheus-exporter-worldping

--- a/manifests/monitoring/grafana/backup-cron.yaml
+++ b/manifests/monitoring/grafana/backup-cron.yaml
@@ -14,6 +14,7 @@ spec:
             - name: registry
           containers:
             - image: ghcr.io/davidsbond/homelab:latest
+              imagePullPolicy: IfNotPresent
               name: grafana-backup
               command:
                 - /bin/grafana-backup

--- a/manifests/storage/bucket-object-cleaner/databases.yaml
+++ b/manifests/storage/bucket-object-cleaner/databases.yaml
@@ -14,6 +14,7 @@ spec:
           - name: registry
           containers:
           - image: ghcr.io/davidsbond/homelab:latest
+            imagePullPolicy: IfNotPresent
             name: bucket-object-cleaner
             command:
             - /bin/bucket-object-cleaner

--- a/manifests/storage/bucket-object-cleaner/minecraft.yaml
+++ b/manifests/storage/bucket-object-cleaner/minecraft.yaml
@@ -14,6 +14,7 @@ spec:
           - name: registry
           containers:
           - image: ghcr.io/davidsbond/homelab:latest
+            imagePullPolicy: IfNotPresent
             name: bucket-object-cleaner
             command:
             - /bin/bucket-object-cleaner

--- a/manifests/storage/postgres/backup-cron.yaml
+++ b/manifests/storage/postgres/backup-cron.yaml
@@ -14,6 +14,7 @@ spec:
             - name: registry
           containers:
             - image: ghcr.io/davidsbond/db-backup:latest
+              imagePullPolicy: IfNotPresent
               name: db-backup
               env:
                 - name: BUCKET_DSN

--- a/manifests/utilities/bitwarden/backup-cron.yaml
+++ b/manifests/utilities/bitwarden/backup-cron.yaml
@@ -25,6 +25,7 @@ spec:
             - name: registry
           containers:
             - image: ghcr.io/davidsbond/db-backup:latest
+              imagePullPolicy: IfNotPresent
               name: db-backup
               env:
                 - name: BUCKET_DSN

--- a/manifests/utilities/photoprism/backup-cron.yaml
+++ b/manifests/utilities/photoprism/backup-cron.yaml
@@ -25,6 +25,7 @@ spec:
             - name: registry
           containers:
             - image: ghcr.io/davidsbond/db-backup:latest
+              imagePullPolicy: IfNotPresent
               name: db-backup
               env:
                 - name: BUCKET_DSN

--- a/manifests/utilities/pihole/ftl-backup-cron.yaml
+++ b/manifests/utilities/pihole/ftl-backup-cron.yaml
@@ -25,6 +25,7 @@ spec:
             - name: registry
           containers:
             - image: ghcr.io/davidsbond/db-backup:latest
+              imagePullPolicy: IfNotPresent
               name: db-backup
               env:
                 - name: BUCKET_DSN

--- a/manifests/utilities/pihole/gravity-backup-cron.yaml
+++ b/manifests/utilities/pihole/gravity-backup-cron.yaml
@@ -25,6 +25,7 @@ spec:
             - name: registry
           containers:
             - image: ghcr.io/davidsbond/db-backup:latest
+              imagePullPolicy: IfNotPresent
               name: db-backup
               env:
                 - name: BUCKET_DSN


### PR DESCRIPTION
This should improve start up times in places where we're using "latest" docker images. If the image
is already on the node then it doesn't need to pull it again.