### PR TITLE
Create deployment for alertmanager-discord.

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -27,6 +27,7 @@ linters:
     - wrapcheck
     - forbidigo
     - wastedassign
+    - cyclop
 
 issues:
   exclude-use-default: false

--- a/internal/alertmanager/handler.go
+++ b/internal/alertmanager/handler.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"encoding/json"
 	"net/http"
+	"time"
 
 	"github.com/gorilla/mux"
 
@@ -27,10 +28,10 @@ type (
 	// The Alert type represents a single alert within a webhook payload.
 	Alert struct {
 		Annotations  map[string]string `json:"annotations"`
-		EndsAt       string            `json:"endsAt"`
+		EndsAt       time.Time         `json:"endsAt"`
 		GeneratorURL string            `json:"generatorURL"`
 		Labels       map[string]string `json:"labels"`
-		StartsAt     string            `json:"startsAt"`
+		StartsAt     time.Time         `json:"startsAt"`
 		Status       string            `json:"status"`
 	}
 

--- a/internal/alertmanager/handler_test.go
+++ b/internal/alertmanager/handler_test.go
@@ -6,6 +6,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"testing"
+	"time"
 
 	"github.com/gorilla/mux"
 	"github.com/stretchr/testify/assert"
@@ -35,8 +36,7 @@ func TestWebhookHandler_Handle(t *testing.T) {
 						Annotations: map[string]string{
 							"description": "some description",
 						},
-						StartsAt:     "2018-08-03T09:52:26.739266876+02:00",
-						EndsAt:       "0001-01-01T00:00:00Z",
+						StartsAt:     time.Date(2020, 1, 1, 0, 0, 0, 0, time.UTC),
 						GeneratorURL: "https://example.com:9090/graph?g0.expr=go_memstats_alloc_bytes+%3E+0\u0026g0.tab=1",
 					},
 				},

--- a/internal/discord/alerts_test.go
+++ b/internal/discord/alerts_test.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"net/http"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 
@@ -30,9 +31,8 @@ func TestAlertDispatcher_Dispatch(t *testing.T) {
 						Annotations: map[string]string{
 							"description": "some description",
 						},
-						StartsAt:     "2018-08-03T09:52:26.739266876+02:00",
-						EndsAt:       "0001-01-01T00:00:00Z",
-						GeneratorURL: "https://example.com:9090/graph?g0.expr=go_memstats_alloc_bytes+%3E+0\u0026g0.tab=1",
+						StartsAt:     time.Date(2020, 1, 1, 0, 0, 0, 0, time.UTC),
+						GeneratorURL: "https://example.com:9090",
 					},
 				},
 				CommonAnnotations: map[string]string{
@@ -57,6 +57,8 @@ func TestAlertDispatcher_Dispatch(t *testing.T) {
 						Title:       "Alert!",
 						Description: "A man has fallen into the river in lego city",
 						Colour:      discord.ColourRed,
+						URL:         "https://example.com:9090",
+						Timestamp:   time.Date(2020, 1, 1, 0, 0, 0, 0, time.UTC),
 						Fields: []discord.Field{
 							{
 								Name:  "description",

--- a/manifests/homelab/alertmanager-discord/deployment.yaml
+++ b/manifests/homelab/alertmanager-discord/deployment.yaml
@@ -1,0 +1,49 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: alertmanager-discord
+  labels:
+    app: alertmanager-discord
+spec:
+  selector:
+    matchLabels:
+      app: alertmanager-discord
+  replicas: 1
+  strategy:
+    type: Recreate
+  template:
+    metadata:
+      annotations:
+        prometheus.io/scrape: 'true'
+        prometheus.io/path: /__/metrics
+        prometheus.io/port: '8081'
+        health.dsb.dev/scrape: 'true'
+      labels:
+        app: alertmanager-discord
+    spec:
+      imagePullSecrets:
+      - name: registry
+      containers:
+      - image: ghcr.io/davidsbond/homelab:latest
+        imagePullPolicy: Always
+        name: alertmanager-discord
+        command:
+        - /bin/alertmanager-discord
+        env:
+        - name: TRACER_DISABLED
+          value: "true"
+        - name: DISCORD_WEBHOOK_URL
+          valueFrom:
+            secretKeyRef:
+              key: webhook.url
+              name: discord
+        - name: MONITORING_DSN
+          valueFrom:
+            secretKeyRef:
+              key: sentry.dsn
+              name: sentry
+        readinessProbe:
+          httpGet:
+            path: /__/health
+            port: 8081
+          initialDelaySeconds: 5

--- a/manifests/homelab/alertmanager-discord/kustomization.yaml
+++ b/manifests/homelab/alertmanager-discord/kustomization.yaml
@@ -1,0 +1,6 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+- deployment.yaml
+- service.yaml

--- a/manifests/homelab/alertmanager-discord/service.yaml
+++ b/manifests/homelab/alertmanager-discord/service.yaml
@@ -1,0 +1,11 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: alertmanager-discord
+spec:
+  selector:
+    app: alertmanager-discord
+  ports:
+    - protocol: TCP
+      name: http
+      port: 80

--- a/manifests/homelab/kustomization.yaml
+++ b/manifests/homelab/kustomization.yaml
@@ -8,6 +8,7 @@ resources:
 - minecraft-backup
 - directory
 - health-dashboard
+- alertmanager-discord
 
 secretGenerator:
 - name: registry
@@ -20,6 +21,9 @@ secretGenerator:
 - name: sentry
   envs:
   - secrets/sentry
+- name: discord
+  envs:
+  - secrets/discord
 
 configMapGenerator:
 - name: tracing

--- a/manifests/homelab/secrets/discord
+++ b/manifests/homelab/secrets/discord
@@ -1,0 +1,5 @@
+# STRONGBOX ENCRYPTED RESOURCE ; See https://github.com/uw-labs/strongbox
+zcMXH+1F+xPTSGU70dPmiITvAc7n2rpAseoQ32c4zcmoidEfnkd6Eny1e57rFZviAKo57l6ykfQm
+PwT2mLIBW1wnnfr+LxUvrqr/SLjTXjT0EGbBjZGmXhk4k3KD5NsptXt6TxX8dTlhjbVGIJkbfjrp
+/2dDirHKPWFjmcczoSyOcb+IEY0YrClPDKxyuWLKj2y/+b3RZkp5d0exOW1Br79Bz5e+/79rHi8W
+lYBq

--- a/manifests/monitoring/config/alertmanager/alertmanager.yaml
+++ b/manifests/monitoring/config/alertmanager/alertmanager.yaml
@@ -8,4 +8,4 @@ route:
 receivers:
 - name: 'default'
   webhook_configs:
-  - url: 'https://google.com'
+  - url: 'http://alertmanager-discord.homelab.svc.cluster.local:80/webhook'


### PR DESCRIPTION
Creates deployment with service, sets up alertmanager to send webhooks to it.
Adds timestamp and URL to discord message, and ensures correct content-type is set.

Signed-off-by: David Bond <davidsbond93@gmail.com>