### PR TITLE
Upgrade jetstack-secure agent to 0.1.31

### DIFF
--- a/manifests/jetstack-secure/agent/deployment.yaml
+++ b/manifests/jetstack-secure/agent/deployment.yaml
@@ -23,7 +23,7 @@ spec:
             - /etc/jetstack-secure/agent/credentials/credentials.json
             - -p
             - 0h1m0s
-          image: quay.io/jetstack/preflight:b2384c5add501ec97516fc906ceab6967ff868a8
+          image: quay.io/jetstack/preflight:v0.1.31
           name: agent
           resources:
             limits:


### PR DESCRIPTION
ARM64 images are standard now, so we can go back to a proper version

Signed-off-by: David Bond <davidsbond93@gmail.com>